### PR TITLE
Added data/MSC01_grayplot_data.mat to git-annex

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* annex.backend=MD5E

--- a/data/MSC01_grayplot_data.mat
+++ b/data/MSC01_grayplot_data.mat
@@ -1,0 +1,1 @@
+../.git/annex/objects/2f/4G/MD5E-s447304081--f63716cb3cb5a118ab8c5745f1376e02.mat/MD5E-s447304081--f63716cb3cb5a118ab8c5745f1376e02.mat


### PR DESCRIPTION
I just pointed annex to your box on dropbox per url you provided.  so now anyone who clones my fork could use git-annex to fetch that file from there (should have done that to other .mat files as well to minimize impact on .git/objects and cloning time ;) ):
```shell
$> git clone https://github.com/yarikoptic/DartmouthMIND_tutorial           
Cloning into 'DartmouthMIND_tutorial'...                         
remote: Counting objects: 161, done.
remote: Compressing objects: 100% (118/118), done.
remote: Total 161 (delta 35), reused 160 (delta 34), pack-reused 0
Receiving objects: 100% (161/161), 186.33 MiB | 5.30 MiB/s, done.
Resolving deltas: 100% (35/35), done.

$> cd DartmouthMIND_tutorial/data/                       

$> git annex get MSC01_grayplot_data.mat     
get MSC01_grayplot_data.mat (from web...) 
mp/DartmouthMIND_tut  27%[++++>               ] 115.25M  6.37MB/s  
```
or just in one datalad call
```
datalad install -g https://github.com/yarikoptic/DartmouthMIND_tutorial 
```

- there is also `git-annex`  branch in my fork now which you would need to pick up from my clone (let me know if you need help with that)
- later I could add a clone to be distributed also through that collection at http://datasets.datalad.org/?dir=/workshops/mind-2017  may be even mirroring that file for extra redundancy ;)